### PR TITLE
build: update dependencies

### DIFF
--- a/fastlane-plugin-sftp.gemspec
+++ b/fastlane-plugin-sftp.gemspec
@@ -23,17 +23,17 @@ Gem::Specification.new do |spec|
   # since this would cause a circular dependency
 
   # spec.add_dependency('your-dependency', '~> 1.0.0')
-  spec.add_dependency('net-ssh', '~> 5.1', '>= 5.1.0')
-  spec.add_dependency('net-sftp', '~> 2.1', '>= 2.1.2')
-  spec.add_dependency('ed25519', '~>1.2')
-  spec.add_dependency('bcrypt_pbkdf', '~>1.0')
+  spec.add_dependency('net-ssh', '~> 7.2.0')
+  spec.add_dependency('net-sftp')
+  spec.add_dependency('ed25519')
+  spec.add_dependency('bcrypt_pbkdf')
 
   spec.add_development_dependency('pry')
   spec.add_development_dependency('bundler')
   spec.add_development_dependency('rspec')
   spec.add_development_dependency('rspec_junit_formatter')
   spec.add_development_dependency('rake')
-  spec.add_development_dependency('rubocop', '0.49.1')
+  spec.add_development_dependency('rubocop')
   spec.add_development_dependency('rubocop-require_tools')
   spec.add_development_dependency('simplecov')
   spec.add_development_dependency('fastlane', '>= 2.116.0')


### PR DESCRIPTION
Fix incompatible with OpenSSL 3.0.

The following is the error message：

```
[19:01:46]: SFTP Uploader running...
[19:01:46]: upload...
[19:01:46]: Using custom port 22...
[19:01:46]: Logging in with username/password...
+------------------------------------+
|            Lane Context            |
+------------------+-----------------+
| DEFAULT_PLATFORM | ios             |
| PLATFORM_NAME    | ios             |
| LANE_NAME        | ios archive_dev |
| VERSION_NUMBER   | 5.2.7           |
+------------------+-----------------+
[19:01:46]: rsa#set_key= is incompatible with OpenSSL 3.0

.....

bundler: failed to load command: fastlane (/Users/grandboy/.rbenv/versions/3.1.4/bin/fastlane)
/Users/grandboy/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/net-ssh-5.2.0/lib/net/ssh/buffer.rb:317:in `set_key': \e[31m[!] rsa#set_key= is incompatible with OpenSSL 3.0\e[0m (OpenSSL::PKey::PKeyError)
        from /Users/grandboy/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/net-ssh-5.2.0/lib/net/ssh/buffer.rb:317:in `read_keyblob'
```